### PR TITLE
Set args as dict instead of string

### DIFF
--- a/hyrex/task.py
+++ b/hyrex/task.py
@@ -221,7 +221,7 @@ class TaskWrapper(Generic[T]):
             id=uuid7(),
             task_name=self.task_identifier,
             queue=self.queue,
-            args=context.model_dump_json(),
+            args=context.model_dump(),
         )
         if self.api_key and self.api_base_url:
             # Enqueue task using API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyrex"
-version = "0.5.1"
+version = "0.5.2"
 description = "Hyrex is a modern, open-source task orchestration framework."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
When using the open-source package in Postgres mode (e.g. not the cloud platform), I ran into errors because the args were being saved the the DB as a string instead of JSON object.

I believe this fixes that.