### PR TITLE
Switch worker child processes to explicitly check the root PID status

### DIFF
--- a/hyrex/worker/admin.py
+++ b/hyrex/worker/admin.py
@@ -15,6 +15,7 @@ from hyrex.worker.messages.admin_messages import (
     TaskHeartbeatMessage,
 )
 from hyrex.worker.messages.root_messages import CancelTaskMessage
+from hyrex.worker.utils import is_process_alive
 
 
 class WorkerAdmin(Process):
@@ -39,6 +40,9 @@ class WorkerAdmin(Process):
         # Incoming messages
         self.admin_message_queue = admin_message_queue
         self._stop_event = Event()
+
+        # To check if root process is running
+        self.parent_pid = os.getpid()
 
     def _message_listener(self):
         while True:
@@ -89,7 +93,7 @@ class WorkerAdmin(Process):
                 self._stop_event.wait(0.5)
 
                 # Confirm parent is still alive
-                if os.getppid() == 1:
+                if not is_process_alive(self.parent_pid):
                     self.logger.warning(
                         "Root process died unexpectedly. Shutting down."
                     )

--- a/hyrex/worker/executor.py
+++ b/hyrex/worker/executor.py
@@ -21,6 +21,7 @@ from hyrex.hyrex_registry import HyrexRegistry
 from hyrex.worker.logging import LogLevel, init_logging
 from hyrex.worker.messages.root_messages import SetExecutorTaskMessage
 from hyrex.worker.worker import HyrexWorker
+from hyrex.worker.utils import is_process_alive
 
 
 def generate_executor_name():
@@ -54,6 +55,9 @@ class WorkerExecutor(Process):
         self.name = generate_executor_name()
         self.dispatcher = None
         self.task_registry: HyrexRegistry = None
+
+        # To check if root process is running
+        self.parent_pid = os.getpid()
 
     def load_worker_module_variables(self):
         sys.path.append(str(Path.cwd()))
@@ -164,7 +168,7 @@ class WorkerExecutor(Process):
             while not self._stop_event.is_set():
                 self.process()
                 # Confirm parent is still alive
-                if os.getppid() == 1:
+                if not is_process_alive(self.parent_pid):
                     self.logger.warning(
                         "Root process died unexpectedly. Shutting down."
                     )

--- a/hyrex/worker/utils.py
+++ b/hyrex/worker/utils.py
@@ -1,0 +1,15 @@
+import os
+import signal
+
+
+def is_process_alive(pid):
+    try:
+        # Signal 0 is a special "null signal" - it tests existence of the process
+        # without sending an actual signal. This is the standard way to check
+        # process existence on Unix systems.
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:  # No process with this PID exists
+        return False
+    except PermissionError:  # Process exists but we don't have permission to signal it
+        return True


### PR DESCRIPTION
… to avoid issues when the root PID is actually 1