### PR TITLE
S3 logs thread cleanup

### DIFF
--- a/hyrex/worker/s3_logs.py
+++ b/hyrex/worker/s3_logs.py
@@ -2,8 +2,14 @@ import contextlib
 import io
 import sys
 import threading
+import atexit
+import logging
 
 import boto3
+
+# Keep track of active upload threads
+_upload_threads_lock = threading.Lock()
+_upload_threads = []
 
 
 def _upload_to_s3_sync(task_id: str, bucket_name: str, output: str):
@@ -16,6 +22,29 @@ def _upload_to_s3_sync(task_id: str, bucket_name: str, output: str):
         print(f"Failed to upload task output to S3: {e}", file=sys.stderr)
 
 
+def _upload_with_tracking(task_id: str, bucket_name: str, output: str):
+    """Wrapper to remove thread from tracking list when done"""
+    try:
+        _upload_to_s3_sync(task_id, bucket_name, output)
+    finally:
+        current_thread = threading.current_thread()
+        with _upload_threads_lock:
+            if current_thread in _upload_threads:
+                _upload_threads.remove(current_thread)
+
+
+@atexit.register
+def wait_for_uploads():
+    """Wait for any pending upload threads to complete"""
+    with _upload_threads_lock:
+        threads_to_wait = _upload_threads[:]
+
+    if threads_to_wait:
+        logging.info(f"Waiting for {len(_upload_threads)} log uploads to complete...")
+        for thread in _upload_threads[:]:
+            thread.join(timeout=3.0)  # Wait up to 3 seconds per thread
+
+
 @contextlib.contextmanager
 def write_task_logs_to_s3(
     task_id: str, bucket_name: str, write_to_console: bool = False
@@ -26,6 +55,7 @@ def write_task_logs_to_s3(
     Args:
         task_id: Identifier for the task
         bucket_name: S3 bucket name for logs
+        write_to_console: Whether to also write output to console
     """
     buffer = io.StringIO()
     original_stdout = sys.stdout
@@ -45,11 +75,14 @@ def write_task_logs_to_s3(
         sys.stderr = original_stderr
 
         if output:
-            # Run in a separate thread to avoid blocking
+            # Create and track non-daemon thread
             thread = threading.Thread(
-                target=_upload_to_s3_sync, args=(task_id, bucket_name, output)
+                target=_upload_with_tracking, args=(task_id, bucket_name, output)
             )
-            thread.daemon = True
+            thread.daemon = False
+
+            with _upload_threads_lock:
+                _upload_threads.append(thread)
             thread.start()
 
 

--- a/hyrex/worker/s3_logs.py
+++ b/hyrex/worker/s3_logs.py
@@ -40,7 +40,7 @@ def wait_for_uploads():
         threads_to_wait = _upload_threads[:]
 
     if threads_to_wait:
-        logging.info(f"Waiting for {len(_upload_threads)} log uploads to complete...")
+        print(f"Waiting for {len(_upload_threads)} log uploads to complete...")
         for thread in _upload_threads[:]:
             thread.join(timeout=3.0)  # Wait up to 3 seconds per thread
 


### PR DESCRIPTION
Don't cut off log writing immediately - give things a few seconds to complete.