### PR TITLE
Add task timeouts

### DIFF
--- a/hyrex/dispatcher/dispatcher.py
+++ b/hyrex/dispatcher/dispatcher.py
@@ -32,6 +32,7 @@ class EnqueueTaskRequest(BaseModel):
     queue: str
     max_retries: int
     priority: int
+    timeout: int
     idempotency_key: str | None
 
 
@@ -44,6 +45,7 @@ class DequeuedTask(BaseModel):
     args: dict
     queue: str
     priority: int
+    timeout: int
     scheduled_start: datetime | None
     queued: datetime
     started: datetime

--- a/hyrex/dispatcher/platform_dispatcher.py
+++ b/hyrex/dispatcher/platform_dispatcher.py
@@ -7,12 +7,8 @@ from uuid import UUID
 import requests
 
 from hyrex import constants
-from hyrex.dispatcher.dispatcher import (
-    DequeuedTask,
-    Dispatcher,
-    EnqueueTaskRequest,
-    TaskStatus,
-)
+from hyrex.dispatcher.dispatcher import (DequeuedTask, Dispatcher,
+                                         EnqueueTaskRequest, TaskStatus)
 
 
 class PlatformDispatcher(Dispatcher):

--- a/hyrex/dispatcher/platform_dispatcher.py
+++ b/hyrex/dispatcher/platform_dispatcher.py
@@ -7,8 +7,12 @@ from uuid import UUID
 import requests
 
 from hyrex import constants
-from hyrex.dispatcher.dispatcher import (DequeuedTask, Dispatcher,
-                                         EnqueueTaskRequest, TaskStatus)
+from hyrex.dispatcher.dispatcher import (
+    DequeuedTask,
+    Dispatcher,
+    EnqueueTaskRequest,
+    TaskStatus,
+)
 
 
 class PlatformDispatcher(Dispatcher):
@@ -220,4 +224,7 @@ class PlatformDispatcher(Dispatcher):
         pass
 
     def get_queues_for_pattern(self, pattern: str) -> list[str]:
+        pass
+
+    def register_task(self, task_name: str, cron: str = None, source_code: str = None):
         pass

--- a/hyrex/dispatcher/postgres_dispatcher.py
+++ b/hyrex/dispatcher/postgres_dispatcher.py
@@ -13,8 +13,12 @@ from psycopg_pool import ConnectionPool
 from uuid_extensions import uuid7
 
 from hyrex import constants, sql
-from hyrex.dispatcher.dispatcher import (DequeuedTask, Dispatcher,
-                                         EnqueueTaskRequest, TaskStatus)
+from hyrex.dispatcher.dispatcher import (
+    DequeuedTask,
+    Dispatcher,
+    EnqueueTaskRequest,
+    TaskStatus,
+)
 
 
 class PostgresDispatcher(Dispatcher):
@@ -252,3 +256,7 @@ class PostgresDispatcher(Dispatcher):
         with self.transaction() as cur:
             cur.execute(sql.GET_UNIQUE_QUEUES_FOR_PATTERN, [pattern])
             return [row[0] for row in cur.fetchall()]
+
+    def register_task(self, task_name: str, cron: str = None, source_code: str = None):
+        with self.transaction() as cur:
+            cur.execute(sql.UPSERT_TASK, [task_name, cron, source_code])

--- a/hyrex/dispatcher/postgres_dispatcher.py
+++ b/hyrex/dispatcher/postgres_dispatcher.py
@@ -101,6 +101,7 @@ class PostgresDispatcher(Dispatcher):
                     args,
                     queue,
                     priority,
+                    timeout,
                     scheduled_start,
                     queued,
                     started,
@@ -114,6 +115,7 @@ class PostgresDispatcher(Dispatcher):
                     args=args,
                     queue=queue,
                     priority=priority,
+                    timeout=timeout,
                     scheduled_start=scheduled_start,
                     queued=queued,
                     started=started,
@@ -179,6 +181,7 @@ class PostgresDispatcher(Dispatcher):
                 task.queue,
                 task.max_retries,
                 task.priority,
+                task.timeout,
                 task.idempotency_key,
             )
             for task in tasks

--- a/hyrex/dispatcher/postgres_dispatcher.py
+++ b/hyrex/dispatcher/postgres_dispatcher.py
@@ -13,12 +13,8 @@ from psycopg_pool import ConnectionPool
 from uuid_extensions import uuid7
 
 from hyrex import constants, sql
-from hyrex.dispatcher.dispatcher import (
-    DequeuedTask,
-    Dispatcher,
-    EnqueueTaskRequest,
-    TaskStatus,
-)
+from hyrex.dispatcher.dispatcher import (DequeuedTask, Dispatcher,
+                                         EnqueueTaskRequest, TaskStatus)
 
 
 class PostgresDispatcher(Dispatcher):

--- a/hyrex/dispatcher/postgres_lite_dispatcher.py
+++ b/hyrex/dispatcher/postgres_lite_dispatcher.py
@@ -9,12 +9,8 @@ from psycopg_pool import ConnectionPool
 from uuid_extensions import uuid7
 
 from hyrex import constants, sql
-from hyrex.dispatcher.dispatcher import (
-    DequeuedTask,
-    Dispatcher,
-    EnqueueTaskRequest,
-    TaskStatus,
-)
+from hyrex.dispatcher.dispatcher import (DequeuedTask, Dispatcher,
+                                         EnqueueTaskRequest, TaskStatus)
 
 
 # Single-threaded variant of Postgres dispatcher. (Slower enqueuing.)

--- a/hyrex/dispatcher/postgres_lite_dispatcher.py
+++ b/hyrex/dispatcher/postgres_lite_dispatcher.py
@@ -89,6 +89,7 @@ class PostgresLiteDispatcher(Dispatcher):
                     args,
                     queue,
                     priority,
+                    timeout,
                     scheduled_start,
                     queued,
                     started,
@@ -102,6 +103,7 @@ class PostgresLiteDispatcher(Dispatcher):
                     args=args,
                     queue=queue,
                     priority=priority,
+                    timeout=timeout,
                     scheduled_start=scheduled_start,
                     queued=queued,
                     started=started,
@@ -123,6 +125,7 @@ class PostgresLiteDispatcher(Dispatcher):
             task.queue,
             task.max_retries,
             task.priority,
+            task.timeout,
             task.idempotency_key,
         )
         with self.transaction() as cur:

--- a/hyrex/hyrex_context.py
+++ b/hyrex/hyrex_context.py
@@ -13,6 +13,7 @@ class HyrexContext(BaseModel):
     task_name: str
     queue: str
     priority: int
+    timeout: int
     scheduled_start: datetime | None
     queued: datetime
     started: datetime

--- a/hyrex/hyrex_registry.py
+++ b/hyrex/hyrex_registry.py
@@ -78,6 +78,7 @@ class HyrexRegistry:
         queue: str | HyrexQueue = constants.DEFAULT_QUEUE,
         cron: str = None,
         max_retries: int = 0,
+        timeout: int = 0,
         priority: int = constants.DEFAULT_PRIORITY,
         on_error: Callable = None,
     ) -> TaskWrapper:
@@ -93,6 +94,7 @@ class HyrexRegistry:
                 queue=queue,
                 cron=cron,
                 max_retries=max_retries,
+                timeout=timeout,
                 priority=priority,
                 dispatcher=self.dispatcher,
                 on_error=on_error,

--- a/hyrex/sql.py
+++ b/hyrex/sql.py
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS hyrex_task_execution (
     priority        SMALLINT                    NOT NULL,
     status          statusenum                  NOT NULL DEFAULT 'queued'::statusenum,
     attempt_number  SMALLINT                    NOT NULL DEFAULT 0,
+    timeout         INT                         NOT NULL DEFAULT 0,
     scheduled_start TIMESTAMP WITH TIME ZONE,
     executor_id     UUID,
     queued          TIMESTAMP WITH TIME ZONE             DEFAULT CURRENT_TIMESTAMP,
@@ -113,7 +114,7 @@ UPDATE hyrex_task_execution as ht
 SET status = 'running', started = CURRENT_TIMESTAMP, last_heartbeat = CURRENT_TIMESTAMP, executor_id = $2
 FROM next_task
 WHERE ht.id = next_task.id
-RETURNING ht.id, ht.durable_id, ht.root_id, ht.parent_id, ht.task_name, ht.args, ht.queue, ht.priority, ht.scheduled_start, ht.queued, ht.started;
+RETURNING ht.id, ht.durable_id, ht.root_id, ht.parent_id, ht.task_name, ht.args, ht.queue, ht.priority, ht.timeout, ht.scheduled_start, ht.queued, ht.started;
 """
 
 FETCH_TASK_WITH_CONCURRENCY = """
@@ -136,7 +137,7 @@ UPDATE hyrex_task_execution as ht
 SET status = 'running', started = CURRENT_TIMESTAMP, last_heartbeat = CURRENT_TIMESTAMP, executor_id = $3
 FROM next_task
 WHERE ht.id = next_task.id
-RETURNING ht.id, ht.durable_id, ht.root_id, ht.parent_id, ht.task_name, ht.args, ht.queue, ht.priority, ht.scheduled_start, ht.queued, ht.started;
+RETURNING ht.id, ht.durable_id, ht.root_id, ht.parent_id, ht.task_name, ht.args, ht.queue, ht.priority, ht.timeout, ht.scheduled_start, ht.queued, ht.started;
 """
 
 CONDITIONALLY_RETRY_TASK = """
@@ -151,6 +152,7 @@ WITH existing_task AS (
         attempt_number,
         max_retries,
         priority,
+        timeout,
         idempotency_key
     FROM hyrex_task_execution
     WHERE id = $1
@@ -169,6 +171,7 @@ INSERT INTO hyrex_task_execution (
     attempt_number,
     max_retries,
     priority,
+    timeout,
     idempotency_key
 )
 SELECT
@@ -184,6 +187,7 @@ SELECT
     attempt_number + 1 AS attempt_number,
     max_retries,
     priority,
+    timeout,
     idempotency_key
 FROM existing_task;
 """
@@ -210,10 +214,11 @@ WITH task_insertion AS (
                                           queue,
                                           max_retries,
                                           priority,
+                                          timeout,
                                           idempotency_key
             )
             VALUES (
-                       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+                       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
                    )
             ON CONFLICT (task_name, idempotency_key)
                 WHERE idempotency_key IS NOT NULL

--- a/hyrex/task.py
+++ b/hyrex/task.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import re
 import time
+from anyio import CancelScope
 from inspect import signature
 from typing import Any, Callable, Generic, TypeVar, get_type_hints
 
@@ -107,9 +108,7 @@ class TaskWrapper(Generic[T]):
         self.max_retries = max_retries
         self.priority = priority
         self.idempotency_key = idempotency_key
-
         self.timeout = timeout
-        self.validate_timeout()
 
         self.dispatcher = dispatcher
         self.on_error = on_error
@@ -126,31 +125,13 @@ class TaskWrapper(Generic[T]):
 
         self.context_klass = context_klass
 
-    def validate_timeout(self):
-        if self.timeout > 0 and not asyncio.iscoroutinefunction(self.func):
-            raise ValidationError("Timeouts only supported for async functions.")
-
     async def async_call(self, context: T):
         self.logger.info(f"Executing task {self.func.__name__} on queue: {self.queue}")
         self._check_type(context)
-
-        # Fast path for sync functions with no timeout
-        if not asyncio.iscoroutinefunction(self.func) and self.timeout == 0:
+        if asyncio.iscoroutinefunction(self.func):
+            return await self.func(context)
+        else:
             return self.func(context)
-
-        # Wrap sync functions that need timeout
-        func = self.func
-        if not asyncio.iscoroutinefunction(func):
-            func = lambda ctx: anyio.to_thread.run_sync(self.func, ctx)
-
-        try:
-            if self.timeout > 0:
-                return await anyio.fail_after(self.timeout, func, context)
-            return await func(context)
-        except TimeoutError:
-            raise TimeoutError(
-                f"Function execution timed out after {self.timeout} seconds"
-            )
 
     # TODO: Re-implement
     def schedule(self):
@@ -240,6 +221,7 @@ class TaskWrapper(Generic[T]):
             queue=self.queue if isinstance(self.queue, str) else self.queue.name,
             args=context.model_dump(),
             max_retries=self.max_retries,
+            timeout=self.timeout,
             priority=self.priority,
             idempotency_key=self.idempotency_key,
         )

--- a/hyrex/task.py
+++ b/hyrex/task.py
@@ -5,9 +5,7 @@ import time
 from inspect import signature
 from typing import Any, Callable, Generic, TypeVar, get_type_hints
 
-import anyio
 import psycopg2
-from anyio import CancelScope
 from pydantic import BaseModel, ValidationError
 from uuid_extensions import uuid7
 

--- a/hyrex/task.py
+++ b/hyrex/task.py
@@ -1,13 +1,13 @@
-import anyio
 import asyncio
 import logging
 import re
 import time
-from anyio import CancelScope
 from inspect import signature
 from typing import Any, Callable, Generic, TypeVar, get_type_hints
 
+import anyio
 import psycopg2
+from anyio import CancelScope
 from pydantic import BaseModel, ValidationError
 from uuid_extensions import uuid7
 

--- a/hyrex/worker/admin.py
+++ b/hyrex/worker/admin.py
@@ -7,11 +7,13 @@ from multiprocessing import Event, Process, Queue
 
 from hyrex.dispatcher import get_dispatcher
 from hyrex.worker.logging import LogLevel, init_logging
-from hyrex.worker.messages.admin_messages import (ExecutorHeartbeatMessage,
-                                                  ExecutorStoppedMessage,
-                                                  NewExecutorMessage,
-                                                  TaskCanceledMessage,
-                                                  TaskHeartbeatMessage)
+from hyrex.worker.messages.admin_messages import (
+    ExecutorHeartbeatMessage,
+    ExecutorStoppedMessage,
+    NewExecutorMessage,
+    TaskCanceledMessage,
+    TaskHeartbeatMessage,
+)
 from hyrex.worker.messages.root_messages import CancelTaskMessage
 from hyrex.worker.utils import is_process_alive
 
@@ -88,6 +90,7 @@ class WorkerAdmin(Process):
                 for task_id in tasks_to_cancel:
                     self.root_message_queue.put(CancelTaskMessage(task_id=task_id))
 
+                # TODO: Switch to notifications to avoid this sleep.
                 self._stop_event.wait(0.5)
 
                 # Confirm parent is still alive

--- a/hyrex/worker/executor.py
+++ b/hyrex/worker/executor.py
@@ -20,16 +20,14 @@ from pydantic import BaseModel
 
 from hyrex.config import EnvVars
 from hyrex.dispatcher import DequeuedTask, EnqueueTaskRequest, get_dispatcher
-from hyrex.hyrex_context import (HyrexContext, clear_hyrex_context,
-                                 set_hyrex_context)
+from hyrex.hyrex_context import HyrexContext, clear_hyrex_context, set_hyrex_context
 from hyrex.hyrex_queue import HyrexQueue
 from hyrex.hyrex_registry import HyrexRegistry
 from hyrex.task import TaskWrapper
 from hyrex.worker.logging import LogLevel, init_logging
 from hyrex.worker.messages.root_messages import SetExecutorTaskMessage
 from hyrex.worker.s3_logs import write_task_logs_to_s3
-from hyrex.worker.utils import (glob_to_postgres_regex, is_glob_pattern,
-                                is_process_alive)
+from hyrex.worker.utils import glob_to_postgres_regex, is_glob_pattern, is_process_alive
 from hyrex.worker.worker import HyrexWorker
 
 
@@ -38,6 +36,14 @@ def generate_executor_name():
     pid = os.getpid()
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
     return f"hyrex-executor-{hostname}-{pid}-{timestamp}"
+
+
+class HyrexTaskTimeout(Exception):
+    pass
+
+
+def timeout_handler(signum, frame):
+    raise HyrexTaskTimeout()
 
 
 class WorkerExecutor(Process):
@@ -113,10 +119,6 @@ class WorkerExecutor(Process):
     def process_item(self, task: DequeuedTask):
         task_wrapper = self.task_registry.get_task(task.task_name)
 
-        if task.timeout > 0:
-            # Message admin
-            pass
-
         context = task_wrapper.context_klass(**task.args)
         if self.logs_s3_bucket:
             with write_task_logs_to_s3(task.id, self.logs_s3_bucket):
@@ -179,6 +181,10 @@ class WorkerExecutor(Process):
 
             # Notify root process of new task
             self.update_current_task(task.id)
+            # Set up timeout
+            if task.timeout > 0:
+                signal.alarm(task.timeout)
+            # Run task
             result = self.process_item(task)
 
             if result is not None:
@@ -230,6 +236,7 @@ class WorkerExecutor(Process):
             return True
         finally:
             self.update_current_task(None)
+            signal.alarm(0)  # Clear alarm
             clear_hyrex_context()
 
     def check_root_process(self):
@@ -306,9 +313,12 @@ class WorkerExecutor(Process):
         if self.register_tasks:
             self.register_tasks_with_dispatcher()
 
-        # Ignore signals, let main process manage shutdown.
+        # Ignore termination signals, let main process manage shutdown.
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
         signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+        # Set up to throw HyrexTaskTimeout on task timeouts.
+        signal.signal(signal.SIGALRM, timeout_handler)
 
         self.logger.info(f"Executor process {self.name} started - checking for tasks.")
 

--- a/hyrex/worker/executor.py
+++ b/hyrex/worker/executor.py
@@ -42,10 +42,6 @@ class HyrexTaskTimeout(Exception):
     pass
 
 
-def timeout_handler(signum, frame):
-    raise HyrexTaskTimeout()
-
-
 class WorkerExecutor(Process):
 
     def __init__(
@@ -317,7 +313,11 @@ class WorkerExecutor(Process):
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
         signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-        # Set up to throw HyrexTaskTimeout on task timeouts.
+        # Set up to throw HyrexTaskTimeout and then end process on task timeout.
+        def timeout_handler(signum, frame):
+            self._stop_event.set()
+            raise HyrexTaskTimeout()
+
         signal.signal(signal.SIGALRM, timeout_handler)
 
         self.logger.info(f"Executor process {self.name} started - checking for tasks.")

--- a/hyrex/worker/executor.py
+++ b/hyrex/worker/executor.py
@@ -109,13 +109,18 @@ class WorkerExecutor(Process):
             self.queue = worker_instance.queue
 
     def process_item(self, task: DequeuedTask):
-        task_func = self.task_registry.get_task(task.task_name)
-        context = task_func.context_klass(**task.args)
+        task_wrapper = self.task_registry.get_task(task.task_name)
+
+        if task.timeout > 0:
+            # Message admin
+            pass
+
+        context = task_wrapper.context_klass(**task.args)
         if self.logs_s3_bucket:
             with write_task_logs_to_s3(task.id, self.logs_s3_bucket):
-                result = asyncio.run(task_func.async_call(context))
+                result = asyncio.run(task_wrapper.async_call(context))
         else:
-            result = asyncio.run(task_func.async_call(context))
+            result = asyncio.run(task_wrapper.async_call(context))
         return result
 
     def fetch_task(self, queue: str, concurrency_limit: int = 0) -> DequeuedTask:
@@ -162,6 +167,7 @@ class WorkerExecutor(Process):
                     task_name=task.task_name,
                     queue=task.queue,
                     priority=task.priority,
+                    timeout=task.timeout,
                     scheduled_start=task.scheduled_start,
                     queued=task.queued,
                     started=task.started,

--- a/hyrex/worker/executor.py
+++ b/hyrex/worker/executor.py
@@ -20,14 +20,16 @@ from pydantic import BaseModel
 
 from hyrex.config import EnvVars
 from hyrex.dispatcher import DequeuedTask, EnqueueTaskRequest, get_dispatcher
-from hyrex.hyrex_context import HyrexContext, clear_hyrex_context, set_hyrex_context
+from hyrex.hyrex_context import (HyrexContext, clear_hyrex_context,
+                                 set_hyrex_context)
 from hyrex.hyrex_queue import HyrexQueue
 from hyrex.hyrex_registry import HyrexRegistry
 from hyrex.task import TaskWrapper
 from hyrex.worker.logging import LogLevel, init_logging
 from hyrex.worker.messages.root_messages import SetExecutorTaskMessage
 from hyrex.worker.s3_logs import write_task_logs_to_s3
-from hyrex.worker.utils import glob_to_postgres_regex, is_glob_pattern, is_process_alive
+from hyrex.worker.utils import (glob_to_postgres_regex, is_glob_pattern,
+                                is_process_alive)
 from hyrex.worker.worker import HyrexWorker
 
 

--- a/hyrex/worker/messages/admin_messages.py
+++ b/hyrex/worker/messages/admin_messages.py
@@ -24,3 +24,8 @@ class ExecutorHeartbeatMessage(BaseModel):
 class TaskHeartbeatMessage(BaseModel):
     timestamp: datetime
     task_ids: list[UUID]
+
+
+class SetTaskTimeoutMessage(BaseModel):
+    timestamp: datetime
+    task_id: UUID

--- a/hyrex/worker/messages/admin_messages.py
+++ b/hyrex/worker/messages/admin_messages.py
@@ -24,8 +24,3 @@ class ExecutorHeartbeatMessage(BaseModel):
 class TaskHeartbeatMessage(BaseModel):
     timestamp: datetime
     task_ids: list[UUID]
-
-
-class SetTaskTimeoutMessage(BaseModel):
-    timestamp: datetime
-    task_id: UUID


### PR DESCRIPTION
Executor will raise a SIGALRM when timeout is hit. Executor process will also stop (and be re-spawned by root process) to avoid any buildup of bad state.