### PR TITLE
Update send() to return a DurableTaskRun instead of a TaskRun

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -5,15 +5,9 @@ from datetime import datetime
 from fastapi import FastAPI
 from pydantic import BaseModel
 
+from .tasks import (EmptyContext, SleepContext, empty_task, error_task,
+                    print_random_number, sleepy_task)
 from .workflow import onboard_user
-from .tasks import (
-    EmptyContext,
-    SleepContext,
-    empty_task,
-    error_task,
-    print_random_number,
-    sleepy_task,
-)
 
 app = FastAPI()
 hyrex_logger = logging.getLogger("hyrex")

--- a/app/api.py
+++ b/app/api.py
@@ -5,8 +5,14 @@ from datetime import datetime
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from .tasks import (EmptyContext, SleepContext, empty_task, error_task,
-                    print_random_number, sleepy_task)
+from .tasks import (
+    EmptyContext,
+    SleepContext,
+    empty_task,
+    error_task,
+    print_random_number,
+    sleepy_task,
+)
 from .workflow import onboard_user
 
 app = FastAPI()

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -49,7 +49,3 @@ def print_random_number():
     print(random_number)
     return {"output": random_number}
     # print(random.random())
-
-
-# TODO: FIX BUG
-# print_random_number.send()

--- a/hyrex/configs.py
+++ b/hyrex/configs.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+
 from pydantic import BaseModel, Field, field_validator
 
 from hyrex.hyrex_queue import HyrexQueue

--- a/hyrex/dispatcher/dispatcher.py
+++ b/hyrex/dispatcher/dispatcher.py
@@ -10,8 +10,15 @@ from pydantic import BaseModel
 
 from hyrex import constants
 from hyrex.hyrex_queue import HyrexQueue
-from hyrex.schemas import (CronJob, CronJobRun, DequeuedTask,
-                           EnqueueTaskRequest, TaskStatus, WorkflowRunRequest)
+from hyrex.schemas import (
+    CronJob,
+    CronJobRun,
+    DequeuedTask,
+    EnqueueTaskRequest,
+    TaskRun,
+    TaskStatus,
+    WorkflowRunRequest,
+)
 
 
 class Dispatcher(ABC):
@@ -199,4 +206,8 @@ class Dispatcher(ABC):
         cron_expr: str,
         should_backfill: bool,
     ) -> None:
+        pass
+
+    @abstractmethod
+    def get_durable_task_run_info(self, durable_id: UUID) -> list[TaskRun]:
         pass

--- a/hyrex/dispatcher/dispatcher.py
+++ b/hyrex/dispatcher/dispatcher.py
@@ -10,14 +10,8 @@ from pydantic import BaseModel
 
 from hyrex import constants
 from hyrex.hyrex_queue import HyrexQueue
-from hyrex.schemas import (
-    CronJob,
-    CronJobRun,
-    DequeuedTask,
-    EnqueueTaskRequest,
-    TaskStatus,
-    WorkflowRunRequest,
-)
+from hyrex.schemas import (CronJob, CronJobRun, DequeuedTask,
+                           EnqueueTaskRequest, TaskStatus, WorkflowRunRequest)
 
 
 class Dispatcher(ABC):

--- a/hyrex/dispatcher/dispatcher.py
+++ b/hyrex/dispatcher/dispatcher.py
@@ -93,6 +93,10 @@ class Dispatcher(ABC):
         pass
 
     @abstractmethod
+    def try_to_cancel_durable_run(self, durable_id: UUID):
+        pass
+
+    @abstractmethod
     def task_canceled(self, task_id: UUID):
         pass
 
@@ -209,5 +213,5 @@ class Dispatcher(ABC):
         pass
 
     @abstractmethod
-    def get_durable_task_run_info(self, durable_id: UUID) -> list[TaskRun]:
+    def get_durable_run_tasks(self, durable_id: UUID) -> list[TaskRun]:
         pass

--- a/hyrex/dispatcher/dispatcher_provider.py
+++ b/hyrex/dispatcher/dispatcher_provider.py
@@ -1,5 +1,6 @@
 import os
 from enum import StrEnum
+
 from hyrex.env_vars import EnvVars
 
 from .dispatcher import Dispatcher

--- a/hyrex/dispatcher/platform_dispatcher.py
+++ b/hyrex/dispatcher/platform_dispatcher.py
@@ -298,5 +298,8 @@ class PlatformDispatcher(Dispatcher):
     def advance_workflow_run(self, workflow_run_id: UUID):
         pass
 
-    def get_durable_task_run_info(self, durable_id: UUID) -> list[TaskRun]:
+    def get_durable_run_tasks(self, durable_id: UUID) -> list[TaskRun]:
+        pass
+
+    def try_to_cancel_durable_run(self, durable_id: UUID):
         pass

--- a/hyrex/dispatcher/platform_dispatcher.py
+++ b/hyrex/dispatcher/platform_dispatcher.py
@@ -5,20 +5,14 @@ from queue import Empty, Queue
 from typing import Type
 from uuid import UUID
 
-from pydantic import BaseModel
 import requests
+from pydantic import BaseModel
 
 from hyrex import constants
 from hyrex.dispatcher.dispatcher import Dispatcher
 from hyrex.hyrex_queue import HyrexQueue
-from hyrex.schemas import (
-    CronJob,
-    CronJobRun,
-    DequeuedTask,
-    EnqueueTaskRequest,
-    TaskStatus,
-    WorkflowRunRequest,
-)
+from hyrex.schemas import (CronJob, CronJobRun, DequeuedTask,
+                           EnqueueTaskRequest, TaskStatus, WorkflowRunRequest)
 
 
 class PlatformDispatcher(Dispatcher):

--- a/hyrex/dispatcher/platform_dispatcher.py
+++ b/hyrex/dispatcher/platform_dispatcher.py
@@ -11,8 +11,15 @@ from pydantic import BaseModel
 from hyrex import constants
 from hyrex.dispatcher.dispatcher import Dispatcher
 from hyrex.hyrex_queue import HyrexQueue
-from hyrex.schemas import (CronJob, CronJobRun, DequeuedTask,
-                           EnqueueTaskRequest, TaskStatus, WorkflowRunRequest)
+from hyrex.schemas import (
+    CronJob,
+    CronJobRun,
+    DequeuedTask,
+    EnqueueTaskRequest,
+    TaskRun,
+    TaskStatus,
+    WorkflowRunRequest,
+)
 
 
 class PlatformDispatcher(Dispatcher):
@@ -289,4 +296,7 @@ class PlatformDispatcher(Dispatcher):
         pass
 
     def advance_workflow_run(self, workflow_run_id: UUID):
+        pass
+
+    def get_durable_task_run_info(self, durable_id: UUID) -> list[TaskRun]:
         pass

--- a/hyrex/dispatcher/postgres_dispatcher.py
+++ b/hyrex/dispatcher/postgres_dispatcher.py
@@ -512,7 +512,7 @@ class PostgresDispatcher(Dispatcher):
         with self.transaction() as cur:
             cur.execute(cron_sql.RELEASE_SCHEDULER_LOCK, [worker_name])
 
-    def get_durable_task_run_info(self, durable_id: UUID) -> list[TaskRun]:
+    def get_durable_run_tasks(self, durable_id: UUID) -> list[TaskRun]:
         with self.transaction() as cur:
             cur.execute(sql.GET_TASK_RUNS_BY_DURABLE_ID, [durable_id])
             results = cur.fetchall()
@@ -556,3 +556,7 @@ class PostgresDispatcher(Dispatcher):
                 task_runs.append(task_run)
 
             return task_runs
+
+    def try_to_cancel_durable_run(self, durable_id: UUID):
+        with self.transaction() as cur:
+            cur.execute(sql.TRY_TO_CANCEL_DURABLE_RUN, [durable_id])

--- a/hyrex/dispatcher/postgres_dispatcher.py
+++ b/hyrex/dispatcher/postgres_dispatcher.py
@@ -17,9 +17,17 @@ from uuid_extensions import uuid7
 from hyrex import constants
 from hyrex.dispatcher.dispatcher import Dispatcher
 from hyrex.hyrex_queue import HyrexQueue
-from hyrex.schemas import (CronJob, CronJobRun, DequeuedTask,
-                           EnqueueTaskRequest, TaskStatus, WorkflowRunRequest,
-                           WorkflowStatus)
+from hyrex.schemas import (
+    CronJob,
+    CronJobRun,
+    DequeuedTask,
+    EnqueueTaskRequest,
+    TaskResult,
+    TaskRun,
+    TaskStatus,
+    WorkflowRunRequest,
+    WorkflowStatus,
+)
 from hyrex.sql import cron_sql, sql, workflow_sql
 
 
@@ -113,6 +121,8 @@ class PostgresDispatcher(Dispatcher):
                     queued,
                     started,
                     workflow_run_id,
+                    attempt_number,
+                    max_retries,
                 ) = row
                 dequeued_task = DequeuedTask(
                     id=task_id,
@@ -128,6 +138,8 @@ class PostgresDispatcher(Dispatcher):
                     queued=queued,
                     started=started,
                     workflow_run_id=workflow_run_id,
+                    attempt_number=attempt_number,
+                    max_retries=max_retries,
                 )
 
         return dequeued_task
@@ -499,3 +511,48 @@ class PostgresDispatcher(Dispatcher):
         """Release the scheduler lock for the specified worker."""
         with self.transaction() as cur:
             cur.execute(cron_sql.RELEASE_SCHEDULER_LOCK, [worker_name])
+
+    def get_durable_task_run_info(self, durable_id: UUID) -> list[TaskRun]:
+        with self.transaction() as cur:
+            cur.execute(sql.GET_TASK_RUNS_BY_DURABLE_ID, [durable_id])
+            results = cur.fetchall()
+
+            task_runs = []
+            for row in results:
+                (
+                    task_id,
+                    max_retries,
+                    attempt_number,
+                    status,
+                    queued,
+                    started,
+                    finished,
+                    task_result_id,
+                    task_result_created_at,
+                    task_result,
+                ) = row
+
+                # Handle the task result
+                task_result_obj = None
+                if task_result_id is not None:
+                    task_result_obj = TaskResult(
+                        task_run_id=task_result_id,
+                        created_at=task_result_created_at,
+                        # Handle None result by defaulting to empty dict
+                        result=task_result if task_result is not None else {},
+                    )
+
+                # Create the TaskRun object without the result field
+                task_run = TaskRun(
+                    id=task_id,
+                    max_retries=max_retries,
+                    attempt_number=attempt_number,
+                    status=status,
+                    queued=queued,
+                    started=started,
+                    finished=finished,
+                    task_result=task_result_obj,
+                )
+                task_runs.append(task_run)
+
+            return task_runs

--- a/hyrex/dispatcher/postgres_dispatcher.py
+++ b/hyrex/dispatcher/postgres_dispatcher.py
@@ -17,16 +17,10 @@ from uuid_extensions import uuid7
 from hyrex import constants
 from hyrex.dispatcher.dispatcher import Dispatcher
 from hyrex.hyrex_queue import HyrexQueue
-from hyrex.schemas import (
-    CronJob,
-    CronJobRun,
-    DequeuedTask,
-    EnqueueTaskRequest,
-    TaskStatus,
-    WorkflowRunRequest,
-    WorkflowStatus,
-)
-from hyrex.sql import sql, workflow_sql, cron_sql
+from hyrex.schemas import (CronJob, CronJobRun, DequeuedTask,
+                           EnqueueTaskRequest, TaskStatus, WorkflowRunRequest,
+                           WorkflowStatus)
+from hyrex.sql import cron_sql, sql, workflow_sql
 
 
 class PostgresDispatcher(Dispatcher):

--- a/hyrex/dispatcher/postgres_lite_dispatcher.py
+++ b/hyrex/dispatcher/postgres_lite_dispatcher.py
@@ -1,11 +1,10 @@
 from psycopg.types.json import Json
-from hyrex.hyrex_queue import HyrexQueue
-from hyrex.sql import sql, cron_sql
 from psycopg_pool import ConnectionPool
 
 from hyrex.dispatcher.postgres_dispatcher import PostgresDispatcher
+from hyrex.hyrex_queue import HyrexQueue
 from hyrex.schemas import EnqueueTaskRequest
-from hyrex.sql import sql
+from hyrex.sql import cron_sql, sql
 
 
 # Single-threaded variant of Postgres dispatcher. (Slower enqueuing.)

--- a/hyrex/durable_run.py
+++ b/hyrex/durable_run.py
@@ -45,7 +45,7 @@ class TaskRun(BaseModel):
         return f"TaskRun<{self.task_name}>[{self.task_run_id}]"
 
 
-class DurableTask:
+class DurableTaskRun:
     def __init__(
         self,
         task_name: str,

--- a/hyrex/durable_run.py
+++ b/hyrex/durable_run.py
@@ -1,9 +1,6 @@
-from datetime import datetime
 import logging
 import time
 from uuid import UUID
-
-from pydantic import BaseModel
 
 from hyrex.dispatcher.dispatcher import Dispatcher
 from hyrex.schemas import TaskRun, TaskStatus
@@ -21,7 +18,7 @@ class DurableTaskRun:
         self.durable_id = durable_id
         self.dispatcher = dispatcher
 
-        self.task_runs = list[TaskRun]
+        self.task_runs: list[TaskRun] = []
 
     def wait(self, timeout: float = 30.0, interval: float = 0.5) -> bool:
         start = time.time()

--- a/hyrex/durable_run.py
+++ b/hyrex/durable_run.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 import time
 from uuid import UUID
@@ -5,13 +6,7 @@ from uuid import UUID
 from pydantic import BaseModel
 
 from hyrex.dispatcher.dispatcher import Dispatcher
-from hyrex.schemas import TaskStatus
-
-
-class TaskRun(BaseModel):
-    task_run_id: UUID
-    status: TaskStatus
-    result: dict
+from hyrex.schemas import TaskRun, TaskStatus
 
 
 class DurableTaskRun:
@@ -28,42 +23,48 @@ class DurableTaskRun:
 
         self.task_runs = list[TaskRun]
 
-    def wait(self, timeout: float = 30.0, interval: float = 1.0):
+    def wait(self, timeout: float = 30.0, interval: float = 0.5) -> bool:
         start = time.time()
         elapsed = 0
-        try:
-            task_status = self.dispatcher.get_task_status(task_id=self.task_run_id)
-        except ValueError:
-            # Task hasn't yet moved from self.local_queue to DB
-            task_status = TaskStatus.queued
 
-        while task_status in [TaskStatus.queued, TaskStatus.running]:
-            if elapsed > timeout:
-                raise TimeoutError("Waiting for task timed out.")
+        run_complete = False
+
+        while not run_complete:
+            self.refresh()
+            for task in self.task_runs:
+                if task.status == TaskStatus.success:
+                    # Completed successfully
+                    return True
+                if (
+                    task.status == TaskStatus.failed
+                    and task.attempt_number == task.max_retries
+                ):
+                    # Failed with no retries left
+                    return False
             time.sleep(interval)
-            task_status = self.dispatcher.get_task_status(task_id=self.task_run_id)
             elapsed = time.time() - start
+            if elapsed > timeout:
+                raise TimeoutError("Waiting for durable task run timed out.")
 
     def get_result(self):
-        # TODO: Find successful task run first.
-        task_run_id = None
-        return self.dispatcher.get_result(task_run_id)
+        self.refresh()
+        for task in self.task_runs:
+            if task.status == TaskStatus.success and task.task_result is not None:
+                # Return only the result dict, not the whole object
+                return task.task_result.result
+        self.logger.warning(f"No result found for durable run {self.durable_id}.")
+        return None
 
     def cancel(self):
-        # TODO: Find currently active task.
-        self.dispatcher.try_to_cancel_task(self.task_run_id)
+        # TODO: Find currently active task or try to mark all tasks as up for cancel.
+        # self.dispatcher.try_to_cancel_task(self.task_run_id)
+        raise NotImplementedError
 
     def __repr__(self):
         return f"DurableTaskRun<{self.task_name}>[{self.durable_id}]"
 
     def refresh(self):
-        # TODO
-        pass
-
-    def wait(self):
-        # TODO
-        pass
-
-    def get_result(self):
-        # TODO
-        pass
+        self.task_runs = self.dispatcher.get_durable_task_run_info(self.durable_id)
+        for task in self.task_runs:
+            pass
+        # TODO: Compute any derived properties

--- a/hyrex/durable_run.py
+++ b/hyrex/durable_run.py
@@ -35,12 +35,16 @@ class DurableTaskRun:
                 if task.status == TaskStatus.success:
                     # Completed successfully
                     return True
-                if (
+                elif (
                     task.status == TaskStatus.failed
                     and task.attempt_number == task.max_retries
                 ):
                     # Failed with no retries left
                     return False
+                elif task.status == TaskStatus.canceled:
+                    # Canceled
+                    return False
+
             time.sleep(interval)
             elapsed = time.time() - start
             if elapsed > timeout:
@@ -56,15 +60,10 @@ class DurableTaskRun:
         return None
 
     def cancel(self):
-        # TODO: Find currently active task or try to mark all tasks as up for cancel.
-        # self.dispatcher.try_to_cancel_task(self.task_run_id)
-        raise NotImplementedError
+        self.dispatcher.try_to_cancel_durable_run(self.durable_id)
 
     def __repr__(self):
         return f"DurableTaskRun<{self.task_name}>[{self.durable_id}]"
 
     def refresh(self):
-        self.task_runs = self.dispatcher.get_durable_task_run_info(self.durable_id)
-        for task in self.task_runs:
-            pass
-        # TODO: Compute any derived properties
+        self.task_runs = self.dispatcher.get_durable_run_tasks(self.durable_id)

--- a/hyrex/durable_run.py
+++ b/hyrex/durable_run.py
@@ -1,22 +1,32 @@
 import logging
+import time
 from uuid import UUID
 
 from pydantic import BaseModel
 
 from hyrex.dispatcher.dispatcher import Dispatcher
+from hyrex.schemas import TaskStatus
 
 
 class TaskRun(BaseModel):
+    task_run_id: UUID
+    status: TaskStatus
+    result: dict
+
+
+class DurableTaskRun:
     def __init__(
         self,
         task_name: str,
-        task_run_id: str,
+        durable_id: UUID,
         dispatcher: Dispatcher,
     ):
-
+        self.logger = logging.getLogger(__name__)
         self.task_name = task_name
-        self.task_run_id = task_run_id
+        self.durable_id = durable_id
         self.dispatcher = dispatcher
+
+        self.task_runs = list[TaskRun]
 
     def wait(self, timeout: float = 30.0, interval: float = 1.0):
         start = time.time()
@@ -34,30 +44,17 @@ class TaskRun(BaseModel):
             task_status = self.dispatcher.get_task_status(task_id=self.task_run_id)
             elapsed = time.time() - start
 
-    # TODO: Implement
     def get_result(self):
-        return self.dispatcher.get_result(self.task_run_id)
+        # TODO: Find successful task run first.
+        task_run_id = None
+        return self.dispatcher.get_result(task_run_id)
 
     def cancel(self):
+        # TODO: Find currently active task.
         self.dispatcher.try_to_cancel_task(self.task_run_id)
 
     def __repr__(self):
-        return f"TaskRun<{self.task_name}>[{self.task_run_id}]"
-
-
-class DurableTaskRun:
-    def __init__(
-        self,
-        task_name: str,
-        durable_id: UUID,
-        dispatcher: Dispatcher,
-    ):
-        self.logger = logging.getLogger(__name__)
-        self.task_name = task_name
-        self.durable_id = durable_id
-        self.dispatcher = dispatcher
-
-        self.task_runs = []
+        return f"DurableTaskRun<{self.task_name}>[{self.durable_id}]"
 
     def refresh(self):
         # TODO

--- a/hyrex/durable_task.py
+++ b/hyrex/durable_task.py
@@ -1,5 +1,48 @@
+import logging
 from uuid import UUID
+
+from pydantic import BaseModel
+
 from hyrex.dispatcher.dispatcher import Dispatcher
+
+
+class TaskRun(BaseModel):
+    def __init__(
+        self,
+        task_name: str,
+        task_run_id: str,
+        dispatcher: Dispatcher,
+    ):
+
+        self.task_name = task_name
+        self.task_run_id = task_run_id
+        self.dispatcher = dispatcher
+
+    def wait(self, timeout: float = 30.0, interval: float = 1.0):
+        start = time.time()
+        elapsed = 0
+        try:
+            task_status = self.dispatcher.get_task_status(task_id=self.task_run_id)
+        except ValueError:
+            # Task hasn't yet moved from self.local_queue to DB
+            task_status = TaskStatus.queued
+
+        while task_status in [TaskStatus.queued, TaskStatus.running]:
+            if elapsed > timeout:
+                raise TimeoutError("Waiting for task timed out.")
+            time.sleep(interval)
+            task_status = self.dispatcher.get_task_status(task_id=self.task_run_id)
+            elapsed = time.time() - start
+
+    # TODO: Implement
+    def get_result(self):
+        return self.dispatcher.get_result(self.task_run_id)
+
+    def cancel(self):
+        self.dispatcher.try_to_cancel_task(self.task_run_id)
+
+    def __repr__(self):
+        return f"TaskRun<{self.task_name}>[{self.task_run_id}]"
 
 
 class DurableTask:
@@ -9,6 +52,7 @@ class DurableTask:
         durable_id: UUID,
         dispatcher: Dispatcher,
     ):
+        self.logger = logging.getLogger(__name__)
         self.task_name = task_name
         self.durable_id = durable_id
         self.dispatcher = dispatcher

--- a/hyrex/durable_task.py
+++ b/hyrex/durable_task.py
@@ -1,0 +1,28 @@
+from uuid import UUID
+from hyrex.dispatcher.dispatcher import Dispatcher
+
+
+class DurableTask:
+    def __init__(
+        self,
+        task_name: str,
+        durable_id: UUID,
+        dispatcher: Dispatcher,
+    ):
+        self.task_name = task_name
+        self.durable_id = durable_id
+        self.dispatcher = dispatcher
+
+        self.task_runs = []
+
+    def refresh(self):
+        # TODO
+        pass
+
+    def wait(self):
+        # TODO
+        pass
+
+    def get_result(self):
+        # TODO
+        pass

--- a/hyrex/hyrex_context.py
+++ b/hyrex/hyrex_context.py
@@ -17,6 +17,8 @@ class HyrexContext(BaseModel):
     queued: datetime
     started: datetime
     executor_id: UUID
+    attempt_number: int
+    max_retries: int
 
 
 # Simple global context

--- a/hyrex/hyrex_registry.py
+++ b/hyrex/hyrex_registry.py
@@ -21,10 +21,12 @@ class HyrexRegistry:
         priority: int = constants.DEFAULT_PRIORITY,
     ):
         self.logger = logging.getLogger(__name__)
+
         if os.getenv(EnvVars.WORKER_PROCESS):
-            self.dispatcher = None
+            self.is_worker_process = True
         else:
-            self.dispatcher = get_dispatcher()
+            self.is_worker_process = False
+        self.dispatcher = get_dispatcher(self.is_worker_process)
 
         self._task_registry: dict[str, TaskWrapper] = {}
         self._queue_registry: dict[str, HyrexQueue] = {}
@@ -108,11 +110,6 @@ class HyrexRegistry:
             return self._queue_registry[queue_name].concurrency_limit
         else:
             return 0
-
-    def set_dispatcher(self, dispatcher: Dispatcher):
-        self.dispatcher = dispatcher
-        for task_wrapper in self._task_registry.values():
-            task_wrapper.dispatcher = dispatcher
 
     def get_on_error_handler(self, task_name: str) -> Callable | None:
         task_wrapper = self._task_registry[task_name]

--- a/hyrex/hyrex_registry.py
+++ b/hyrex/hyrex_registry.py
@@ -8,7 +8,7 @@ from hyrex.configs import ConfigPhase, TaskConfig, WorkflowConfig
 from hyrex.dispatcher import Dispatcher, get_dispatcher
 from hyrex.env_vars import EnvVars
 from hyrex.hyrex_queue import HyrexQueue
-from hyrex.task import TaskWrapper
+from hyrex.task_wrapper import TaskWrapper
 from hyrex.workflow.workflow import HyrexWorkflow
 from hyrex.workflow.workflow_builder import WorkflowBuilder
 

--- a/hyrex/hyrex_registry.py
+++ b/hyrex/hyrex_registry.py
@@ -4,11 +4,11 @@ import os
 from typing import Callable
 
 from hyrex import constants
-from hyrex.env_vars import EnvVars
+from hyrex.configs import ConfigPhase, TaskConfig, WorkflowConfig
 from hyrex.dispatcher import Dispatcher, get_dispatcher
+from hyrex.env_vars import EnvVars
 from hyrex.hyrex_queue import HyrexQueue
 from hyrex.task import TaskWrapper
-from hyrex.configs import ConfigPhase, TaskConfig, WorkflowConfig
 from hyrex.workflow.workflow import HyrexWorkflow
 from hyrex.workflow.workflow_builder import WorkflowBuilder
 

--- a/hyrex/schemas.py
+++ b/hyrex/schemas.py
@@ -48,6 +48,26 @@ class DequeuedTask(BaseModel):
     queued: datetime
     started: datetime
     workflow_run_id: UUID | None
+    attempt_number: int
+    max_retries: int
+
+
+class TaskResult(BaseModel):
+    task_run_id: UUID
+    created_at: datetime
+    result: dict
+
+
+# For tracking durable runs:
+class TaskRun(BaseModel):
+    id: UUID
+    max_retries: int
+    attempt_number: int
+    status: TaskStatus
+    queued: datetime
+    started: datetime | None
+    finished: datetime | None
+    task_result: TaskResult | None
 
 
 class WorkflowStatus(StrEnum):

--- a/hyrex/sql/cron_sql.py
+++ b/hyrex/sql/cron_sql.py
@@ -1,5 +1,7 @@
-# import { CronJobRun } from "../../../HyrexCronScheduler";
-# import { SerializedTaskRequest } from "../../HyrexDispatcher";
+import json
+from typing import Any, Dict, List
+
+from hyrex.schemas import CronJobRun, EnqueueTaskRequest
 
 CREATE_HYREX_CRON_JOB_TABLE = """
 DO $$
@@ -119,19 +121,6 @@ UPDATE_CRON_JOB_CONFIRMATION_TS = """
     SET scheduled_jobs_confirmed_until = now()
     WHERE jobid = $1;
 """
-
-from datetime import datetime
-import json
-from pydantic import BaseModel
-from typing import List, Dict, Any
-
-from hyrex.schemas import EnqueueTaskRequest
-
-
-class CronJobRun(BaseModel):
-    jobid: int
-    command: str
-    schedule_time: datetime
 
 
 def cron_job_runs_to_sql(runs: List[CronJobRun]) -> Dict[str, Any]:
@@ -314,6 +303,7 @@ CREATE_CRON_JOB_FOR_TASK = """
     VALUES ($1, $2, $3, 'TASK')
     ON CONFLICT (jobname) 
     DO UPDATE SET 
+        activated_at = CURRENT_TIMESTAMP,
         schedule = EXCLUDED.schedule,
         command = EXCLUDED.command,
         job_source = 'TASK',
@@ -325,6 +315,7 @@ CREATE_CRON_JOB_FOR_SQL_QUERY = """
     VALUES ($1, $2, $3, $4, 'SYSTEM')
     ON CONFLICT (jobname) 
     DO UPDATE SET 
+        activated_at = CURRENT_TIMESTAMP,
         schedule = EXCLUDED.schedule,
         command = EXCLUDED.command,
         should_backfill = EXCLUDED.should_backfill,

--- a/hyrex/sql/sql.py
+++ b/hyrex/sql/sql.py
@@ -332,6 +332,15 @@ TRY_TO_CANCEL_TASK = """
     WHERE id = $1 AND status IN ('running', 'queued');
 """
 
+TRY_TO_CANCEL_DURABLE_RUN = """
+    UPDATE hyrex_task_run
+    SET status = CASE 
+                WHEN status = 'running' THEN 'up_for_cancel'::task_run_status
+                WHEN status = 'queued' THEN 'canceled'::task_run_status
+                END
+    WHERE durable_id = $1 AND status IN ('running', 'queued');
+"""
+
 TASK_CANCELED = """
     UPDATE hyrex_task_run
     SET status = 'canceled'

--- a/hyrex/sql/sql.py
+++ b/hyrex/sql/sql.py
@@ -163,7 +163,7 @@ UPDATE hyrex_task_run as ht
 SET status = 'running', started = CURRENT_TIMESTAMP, last_heartbeat = CURRENT_TIMESTAMP, executor_id = $2
 FROM next_task
 WHERE ht.id = next_task.id
-RETURNING ht.id, ht.durable_id, ht.root_id, ht.parent_id, ht.task_name, ht.args, ht.queue, ht.priority, ht.timeout_seconds, ht.scheduled_start, ht.queued, ht.started, ht.workflow_run_id;
+RETURNING ht.id, ht.durable_id, ht.root_id, ht.parent_id, ht.task_name, ht.args, ht.queue, ht.priority, ht.timeout_seconds, ht.scheduled_start, ht.queued, ht.started, ht.workflow_run_id, ht.attempt_number, ht.max_retries;
 """
 
 FETCH_TASK_WITH_CONCURRENCY = """
@@ -187,7 +187,7 @@ UPDATE hyrex_task_run as ht
 SET status = 'running', started = CURRENT_TIMESTAMP, last_heartbeat = CURRENT_TIMESTAMP, executor_id = $3
 FROM next_task
 WHERE ht.id = next_task.id
-RETURNING ht.id, ht.durable_id, ht.root_id, ht.parent_id, ht.task_name, ht.args, ht.queue, ht.priority, ht.timeout_seconds, ht.scheduled_start, ht.queued, ht.started, ht.workflow_run_id;
+RETURNING ht.id, ht.durable_id, ht.root_id, ht.parent_id, ht.task_name, ht.args, ht.queue, ht.priority, ht.timeout_seconds, ht.scheduled_start, ht.queued, ht.started, ht.workflow_run_id, ht.attempt_number, ht.max_retries;
 """
 
 CONDITIONALLY_RETRY_TASK = """
@@ -428,6 +428,28 @@ GET_QUEUES_FOR_PATTERN = """
                         queue_count qc
                    WHERE qc.cnt > 100000) sub
              WHERE rn <= 100000) final_result;"""
+
+GET_TASK_RUNS_BY_DURABLE_ID = """
+    SELECT 
+        tr.id,
+        tr.max_retries,
+        tr.attempt_number,
+        tr.status,
+        tr.queued,
+        tr.started,
+        tr.finished,
+        tres.task_id,
+        tres.created_at,
+        tres.result
+    FROM 
+        hyrex_task_run tr
+    LEFT JOIN 
+        hyrex_task_result tres ON tr.id = tres.task_id
+    WHERE 
+        tr.durable_id = $1
+    ORDER BY 
+        tr.queued DESC
+"""
 
 MARK_LOST_TASKS = """
     SELECT id, task_name, queue, last_heartbeat

--- a/hyrex/task.py
+++ b/hyrex/task.py
@@ -9,12 +9,13 @@ import psycopg
 from pydantic import BaseModel, ValidationError
 from uuid_extensions import uuid7
 
+from hyrex.configs import ConfigPhase, TaskConfig
 from hyrex.dispatcher import Dispatcher
 from hyrex.hyrex_context import get_hyrex_context
 from hyrex.hyrex_queue import HyrexQueue
 from hyrex.schemas import EnqueueTaskRequest, TaskStatus
-from hyrex.configs import ConfigPhase, TaskConfig
-from hyrex.workflow.workflow_builder_context import get_current_workflow_builder
+from hyrex.workflow.workflow_builder_context import \
+    get_current_workflow_builder
 
 T = TypeVar("T", bound=BaseModel)
 

--- a/hyrex/task_wrapper.py
+++ b/hyrex/task_wrapper.py
@@ -9,63 +9,13 @@ import psycopg
 from pydantic import BaseModel, ValidationError
 from uuid_extensions import uuid7
 
-from hyrex.configs import ConfigPhase, TaskConfig
 from hyrex.dispatcher import Dispatcher
+from hyrex.durable_run import DurableTaskRun
 from hyrex.hyrex_context import get_hyrex_context
 from hyrex.hyrex_queue import HyrexQueue
 from hyrex.schemas import EnqueueTaskRequest, TaskStatus
-from hyrex.workflow.workflow_builder_context import \
-    get_current_workflow_builder
-
-T = TypeVar("T", bound=BaseModel)
-
-
-class UnboundTaskException(Exception):
-    """Exception raised for errors in the task binding."""
-
-    def __init__(self, message="Task is unbound."):
-        self.message = message
-        super().__init__(self.message)
-
-
-class TaskRun:
-    def __init__(
-        self,
-        task_name: str,
-        task_run_id: str,
-        dispatcher: Dispatcher,
-    ):
-        self.logger = logging.getLogger(__name__)
-
-        self.task_name = task_name
-        self.task_run_id = task_run_id
-        self.dispatcher = dispatcher
-
-    def wait(self, timeout: float = 30.0, interval: float = 1.0):
-        start = time.time()
-        elapsed = 0
-        try:
-            task_status = self.dispatcher.get_task_status(task_id=self.task_run_id)
-        except ValueError:
-            # Task hasn't yet moved from self.local_queue to DB
-            task_status = TaskStatus.queued
-
-        while task_status in [TaskStatus.queued, TaskStatus.running]:
-            if elapsed > timeout:
-                raise TimeoutError("Waiting for task timed out.")
-            time.sleep(interval)
-            task_status = self.dispatcher.get_task_status(task_id=self.task_run_id)
-            elapsed = time.time() - start
-
-    # TODO: Implement
-    def get_result(self):
-        return self.dispatcher.get_result(self.task_run_id)
-
-    def cancel(self):
-        self.dispatcher.try_to_cancel_task(self.task_run_id)
-
-    def __repr__(self):
-        return f"TaskRun<{self.task_name}>[{self.task_run_id}]"
+from hyrex.configs import ConfigPhase, TaskConfig
+from hyrex.workflow.workflow_builder_context import get_current_workflow_builder
 
 
 def validate_error_handler(handler: Callable) -> None:
@@ -194,7 +144,7 @@ class TaskWrapper:
     def send(
         self,
         context=None,
-    ) -> TaskRun:
+    ) -> DurableTaskRun:
         self.logger.info(
             f"Sending task {self.func.__name__} to queue: {self.task_config.queue}"
         )
@@ -233,9 +183,9 @@ class TaskWrapper:
 
         self.dispatcher.enqueue([task])
 
-        return TaskRun(
+        return DurableTaskRun(
             task_name=self.task_identifier,
-            task_run_id=task.id,
+            durable_id=task.id,
             dispatcher=self.dispatcher,
         )
 

--- a/hyrex/worker/cron_scheduler.py
+++ b/hyrex/worker/cron_scheduler.py
@@ -47,6 +47,7 @@ class WorkerCronScheduler(Process):
 
     def impute_scheduled_cron_job_runs(self, cron_job: CronJob) -> list[CronJobRun]:
         # Create iterator starting from the last confirmed date
+        # TODO: Should this go from activated_at if it's reactivated?
         iterator = croniter(cron_job.schedule, cron_job.scheduled_jobs_confirmed_until)
 
         cron_job_runs = []
@@ -138,7 +139,6 @@ class WorkerCronScheduler(Process):
 
     def stop(self):
         self.logger.info("Stopping cron scheduler.")
-        # TODO: Return lock
         if self.lock_id:
             self.logger.info("Releasing scheduler lock...")
             self.dispatcher.release_scheduler_lock(self.worker_name)

--- a/hyrex/worker/cron_scheduler.py
+++ b/hyrex/worker/cron_scheduler.py
@@ -46,9 +46,9 @@ class WorkerCronScheduler(Process):
         self.dispatcher.update_cron_confirmation_timestamp(cron_job.jobid)
 
     def impute_scheduled_cron_job_runs(self, cron_job: CronJob) -> list[CronJobRun]:
-        # Create iterator starting from the last confirmed date
-        # TODO: Should this go from activated_at if it's reactivated?
-        iterator = croniter(cron_job.schedule, cron_job.scheduled_jobs_confirmed_until)
+        # Create iterator starting from the last confirmed date or activation date
+        start_time = max(cron_job.activated_at, cron_job.scheduled_jobs_confirmed_until)
+        iterator = croniter(cron_job.schedule, start_time=start_time)
 
         cron_job_runs = []
         now = datetime.now(timezone.utc)  # Create timezone-aware UTC datetime

--- a/hyrex/worker/executor/executor.py
+++ b/hyrex/worker/executor/executor.py
@@ -23,16 +23,14 @@ from hyrex.dispatcher import DequeuedTask, get_dispatcher
 from hyrex.env_vars import EnvVars
 from hyrex.hyrex_app import HyrexApp, HyrexAppInfo
 from hyrex.hyrex_cache import HyrexCacheManager
-from hyrex.hyrex_context import (HyrexContext, clear_hyrex_context,
-                                 set_hyrex_context)
+from hyrex.hyrex_context import HyrexContext, clear_hyrex_context, set_hyrex_context
 from hyrex.hyrex_queue import HyrexQueue
 from hyrex.hyrex_registry import HyrexRegistry
 from hyrex.worker.executor.time_series_averager import TimeSeriesAverager
 from hyrex.worker.logging import LogLevel, init_logging
 from hyrex.worker.messages.root_messages import SetExecutorTaskMessage
 from hyrex.worker.s3_logs import write_task_logs_to_s3
-from hyrex.worker.utils import (glob_to_postgres_regex, is_glob_pattern,
-                                is_process_alive)
+from hyrex.worker.utils import glob_to_postgres_regex, is_glob_pattern, is_process_alive
 
 
 def generate_executor_name():
@@ -176,15 +174,15 @@ class WorkerExecutor(Process):
             SetExecutorTaskMessage(executor_id=self.executor_id, task_id=task_id),
         )
 
-    def process(self, queue: HyrexQueue):
+    def process(self, queue: HyrexQueue) -> bool:
         """Returns True if a task is found and attempted, False otherwise"""
-        try:
-            task: DequeuedTask | None = self.fetch_task(
-                queue=queue.name, concurrency_limit=queue.concurrency_limit
-            )
-            if not task:
-                return False
+        task: DequeuedTask | None = self.fetch_task(
+            queue=queue.name, concurrency_limit=queue.concurrency_limit
+        )
+        if not task:
+            return False
 
+        try:
             set_hyrex_context(
                 HyrexContext(
                     task_id=task.id,
@@ -310,6 +308,7 @@ class WorkerExecutor(Process):
             self.check_root_process()
 
     def run_round_robin_loop(self):
+        self.update_queue_list()
         last_queue_refresh = time.monotonic()
         no_task_count = 0
 
@@ -323,8 +322,7 @@ class WorkerExecutor(Process):
             ):
                 self.update_queue_list()
                 last_queue_refresh = time.monotonic()
-
-            no_task_count = 0
+                no_task_count = 0
 
             for queue in self.queues:
                 self.check_root_process()

--- a/hyrex/worker/executor/executor.py
+++ b/hyrex/worker/executor/executor.py
@@ -74,7 +74,6 @@ class WorkerExecutor(Process):
         self.refresh_queue_duration_averager = TimeSeriesAverager()
         self.dequeue_duration_averager = TimeSeriesAverager()
 
-        self.dispatcher = None
         self.registry: HyrexRegistry = None
         self.register_app = register_app
 
@@ -339,16 +338,6 @@ class WorkerExecutor(Process):
                 if no_task_count >= 5:
                     break
 
-    # Now done in run() line self.registry.register_with_db()
-    # def register_tasks_with_dispatcher(self):
-    #     """Register all current tasks with dispatcher."""
-    #     for task_wrapper in self.registry.get_task_wrappers():
-    #         self.dispatcher.register_task(
-    #             task_name=task_wrapper.task_identifier,
-    #             cron=task_wrapper.cron,
-    #             source_code=inspect.getsource(task_wrapper.func),
-    #         )
-
     def register_hyrex_app(self):
         self.dispatcher.register_app(self.app_info.model_dump_json())
 
@@ -377,7 +366,6 @@ class WorkerExecutor(Process):
             queues=self.queues,
             worker_name=self.worker_name,
         )
-        self.registry.set_dispatcher(self.dispatcher)
 
         # Ignore termination signals, let main process manage shutdown.
         signal.signal(signal.SIGTERM, signal.SIG_IGN)

--- a/hyrex/worker/executor/executor.py
+++ b/hyrex/worker/executor/executor.py
@@ -19,18 +19,20 @@ from psycopg.types.json import Json
 from pydantic import BaseModel
 
 from hyrex import constants
-from hyrex.env_vars import EnvVars
 from hyrex.dispatcher import DequeuedTask, get_dispatcher
+from hyrex.env_vars import EnvVars
 from hyrex.hyrex_app import HyrexApp, HyrexAppInfo
 from hyrex.hyrex_cache import HyrexCacheManager
-from hyrex.hyrex_context import HyrexContext, clear_hyrex_context, set_hyrex_context
+from hyrex.hyrex_context import (HyrexContext, clear_hyrex_context,
+                                 set_hyrex_context)
 from hyrex.hyrex_queue import HyrexQueue
 from hyrex.hyrex_registry import HyrexRegistry
 from hyrex.worker.executor.time_series_averager import TimeSeriesAverager
 from hyrex.worker.logging import LogLevel, init_logging
 from hyrex.worker.messages.root_messages import SetExecutorTaskMessage
 from hyrex.worker.s3_logs import write_task_logs_to_s3
-from hyrex.worker.utils import glob_to_postgres_regex, is_glob_pattern, is_process_alive
+from hyrex.worker.utils import (glob_to_postgres_regex, is_glob_pattern,
+                                is_process_alive)
 
 
 def generate_executor_name():

--- a/hyrex/worker/executor/executor.py
+++ b/hyrex/worker/executor/executor.py
@@ -199,6 +199,8 @@ class WorkerExecutor(Process):
                     queued=task.queued,
                     started=task.started,
                     executor_id=self.executor_id,
+                    attempt_number=task.attempt_number,
+                    max_retries=task.max_retries,
                 )
             )
 

--- a/hyrex/worker/executor/executor.py
+++ b/hyrex/worker/executor/executor.py
@@ -167,9 +167,6 @@ class WorkerExecutor(Process):
     def attempt_retry(self, task_id: UUID):
         self.dispatcher.attempt_retry(task_id=task_id)
 
-    def reset_or_cancel_task(self, task_id: UUID):
-        self.dispatcher.reset_or_cancel_task(task_id=task_id)
-
     # Notifies root process of current task being processed.
     def update_current_task(self, task_id: UUID):
         self.root_message_queue.put(

--- a/hyrex/worker/root_process.py
+++ b/hyrex/worker/root_process.py
@@ -13,18 +13,14 @@ from hyrex.worker.admin import WorkerAdmin
 from hyrex.worker.cron_scheduler import WorkerCronScheduler
 from hyrex.worker.executor.executor import WorkerExecutor
 from hyrex.worker.logging import LogLevel, init_logging
-from hyrex.worker.messages.admin_messages import (
-    ExecutorHeartbeatMessage,
-    ExecutorStoppedMessage,
-    NewExecutorMessage,
-    TaskCanceledMessage,
-    TaskHeartbeatMessage,
-)
-from hyrex.worker.messages.root_messages import (
-    CancelTaskMessage,
-    HeartbeatRequestMessage,
-    SetExecutorTaskMessage,
-)
+from hyrex.worker.messages.admin_messages import (ExecutorHeartbeatMessage,
+                                                  ExecutorStoppedMessage,
+                                                  NewExecutorMessage,
+                                                  TaskCanceledMessage,
+                                                  TaskHeartbeatMessage)
+from hyrex.worker.messages.root_messages import (CancelTaskMessage,
+                                                 HeartbeatRequestMessage,
+                                                 SetExecutorTaskMessage)
 
 
 class WorkerRootProcess:

--- a/hyrex/workflow/workflow.py
+++ b/hyrex/workflow/workflow.py
@@ -1,12 +1,13 @@
 from typing import Type
 from uuid import UUID
-from uuid_extensions import uuid7
-from pydantic import BaseModel
 
+from pydantic import BaseModel
+from uuid_extensions import uuid7
+
+from hyrex.configs import ConfigPhase, TaskConfig, WorkflowConfig
 from hyrex.dispatcher.dispatcher import Dispatcher
 from hyrex.hyrex_queue import HyrexQueue
 from hyrex.schemas import EnqueueTaskRequest, TaskStatus, WorkflowRunRequest
-from hyrex.configs import ConfigPhase, TaskConfig, WorkflowConfig
 from hyrex.workflow.workflow_builder import DagNode, WorkflowBuilder
 
 

--- a/hyrex/workflow/workflow_builder.py
+++ b/hyrex/workflow/workflow_builder.py
@@ -2,9 +2,11 @@ import collections
 import json
 from typing import Sequence
 
-from hyrex.task import TaskWrapper
+from hyrex.task_wrapper import TaskWrapper
 from hyrex.workflow.workflow_builder_context import (
-    clear_current_workflow_builder, set_current_workflow_builder)
+    clear_current_workflow_builder,
+    set_current_workflow_builder,
+)
 
 
 class DagNode:

--- a/hyrex/workflow/workflow_builder.py
+++ b/hyrex/workflow/workflow_builder.py
@@ -4,9 +4,7 @@ from typing import Sequence
 
 from hyrex.task import TaskWrapper
 from hyrex.workflow.workflow_builder_context import (
-    set_current_workflow_builder,
-    clear_current_workflow_builder,
-)
+    clear_current_workflow_builder, set_current_workflow_builder)
 
 
 class DagNode:

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -6,12 +6,12 @@ import psycopg  # Added import for database connections
 import pytest
 from pydantic import BaseModel
 
-from hyrex.models import create_tables
-from hyrex.hyrex_app import HyrexApp
-from hyrex.hyrex_registry import HyrexRegistry
 from hyrex.constants import DEFAULT_QUEUE
 from hyrex.dispatcher import get_dispatcher
 from hyrex.dispatcher.postgres_dispatcher import PostgresDispatcher
+from hyrex.hyrex_app import HyrexApp
+from hyrex.hyrex_registry import HyrexRegistry
+from hyrex.models import create_tables
 from hyrex.worker.root_process import run_worker
 
 logging.basicConfig(level=logging.INFO)
@@ -45,8 +45,9 @@ def register_tasks(registry: HyrexRegistry):
 
 def worker_process(db_connection_string):
     import os
+
     from hyrex.env_vars import EnvVars
-    
+
     # Set worker process environment variable
     os.environ[EnvVars.WORKER_PROCESS] = "1"
     os.environ[EnvVars.DATABASE_URL] = db_connection_string


### PR DESCRIPTION
Now, `wait()`, `get_result()`, and `cancel()` all refer to the durable task rather than the individual task run.