### PR TITLE
Support arbitrary keyword args

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -5,8 +5,16 @@ from datetime import datetime
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from .tasks import (EmptyContext, SleepContext, empty_task, error_task,
-                    print_random_number, root_level_task, sleepy_task)
+from .tasks import (
+    EmptyContext,
+    SleepContext,
+    empty_task,
+    error_task,
+    print_random_number,
+    root_level_task,
+    sleepy_task,
+    spawn_empty_tasks,
+)
 from .workflow import OnboardUserWorkflowArg, onboard_user
 
 app = FastAPI()
@@ -43,6 +51,11 @@ async def generate_tasks(num_tasks: int):
 @app.get("/empty-task/")
 async def run_empty_task():
     empty_task.send()
+
+
+@app.get("/spawn-empty-tasks/")
+async def send_empty_tasks():
+    spawn_empty_tasks.send()
 
 
 @app.get("/sleepy-task/")

--- a/app/api.py
+++ b/app/api.py
@@ -55,7 +55,8 @@ async def run_empty_task():
 
 @app.get("/spawn-empty-tasks/")
 async def send_empty_tasks():
-    spawn_empty_tasks.send()
+    # Test out type hints
+    spawn_empty_tasks.send(num=50)
 
 
 @app.get("/sleepy-task/")

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -32,6 +32,12 @@ def empty_task():
     print("Task complete.")
 
 
+@hy.task
+def spawn_empty_tasks(num: int):
+    for _ in range(num):
+        empty_task.send()
+
+
 def error_handler():
     print("It's working a bit!")
     print(get_hyrex_context())

--- a/hyrex/dispatcher/postgres_dispatcher.py
+++ b/hyrex/dispatcher/postgres_dispatcher.py
@@ -17,9 +17,17 @@ from uuid_extensions import uuid7
 from hyrex import constants
 from hyrex.dispatcher.dispatcher import Dispatcher
 from hyrex.hyrex_queue import HyrexQueue
-from hyrex.schemas import (CronJob, CronJobRun, DequeuedTask,
-                           EnqueueTaskRequest, TaskResult, TaskRun, TaskStatus,
-                           WorkflowRunRequest, WorkflowStatus)
+from hyrex.schemas import (
+    CronJob,
+    CronJobRun,
+    DequeuedTask,
+    EnqueueTaskRequest,
+    TaskResult,
+    TaskRun,
+    TaskStatus,
+    WorkflowRunRequest,
+    WorkflowStatus,
+)
 from hyrex.sql import cron_sql, sql, workflow_sql
 
 
@@ -319,7 +327,7 @@ class PostgresDispatcher(Dispatcher):
     def register_task(
         self,
         task_name: str,
-        arg_schema: Type[BaseModel] | None,
+        arg_schema: dict,
         default_config: dict,
         cron: str = None,
         source_code: str = None,
@@ -329,7 +337,7 @@ class PostgresDispatcher(Dispatcher):
                 sql.UPSERT_TASK,
                 [
                     task_name,
-                    Json(arg_schema.model_json_schema()) if arg_schema else None,
+                    Json(arg_schema),
                     Json(default_config),
                     cron,
                     source_code,

--- a/hyrex/hyrex_registry.py
+++ b/hyrex/hyrex_registry.py
@@ -1,14 +1,14 @@
 import inspect
 import logging
 import os
-from typing import Callable
+from typing import Callable, overload
 
 from hyrex import constants
 from hyrex.configs import ConfigPhase, TaskConfig, WorkflowConfig
 from hyrex.dispatcher import Dispatcher, get_dispatcher
 from hyrex.env_vars import EnvVars
 from hyrex.hyrex_queue import HyrexQueue
-from hyrex.task_wrapper import TaskWrapper
+from hyrex.task_wrapper import P, R, TaskWrapper
 from hyrex.workflow.workflow import HyrexWorkflow
 from hyrex.workflow.workflow_builder import WorkflowBuilder
 
@@ -137,9 +137,13 @@ class HyrexRegistry:
         for workflow in registry.get_workflows():
             self.register_workflow(workflow=workflow)
 
+    @overload
+    def task(self, func: Callable[P, R]) -> TaskWrapper[P, R]: ...
+
+    @overload
     def task(
         self,
-        func: Callable = None,
+        func: None = None,
         *,
         queue: str | HyrexQueue = constants.DEFAULT_QUEUE,
         cron: str | None = None,
@@ -148,12 +152,25 @@ class HyrexRegistry:
         priority: int = constants.DEFAULT_PRIORITY,
         on_error: Callable | None = None,
         retry_backoff: int | Callable[[int], int] | None = None,
-    ) -> TaskWrapper:
+    ) -> Callable[[Callable[P, R]], TaskWrapper[P, R]]: ...
+
+    def task(
+        self,
+        func: Callable[P, R] | None = None,
+        *,
+        queue: str | HyrexQueue = constants.DEFAULT_QUEUE,
+        cron: str | None = None,
+        max_retries: int = 0,
+        timeout_seconds: int | None = None,
+        priority: int = constants.DEFAULT_PRIORITY,
+        on_error: Callable | None = None,
+        retry_backoff: int | Callable[[int], int] | None = None,
+    ) -> TaskWrapper[P, R] | Callable[[Callable[P, R]], TaskWrapper[P, R]]:
         """
         Create task decorator
         """
 
-        def decorator(func: Callable) -> TaskWrapper:
+        def decorator(func: Callable[P, R]) -> TaskWrapper[P, R]:
             task_identifier = func.__name__
             decorated_task_config = TaskConfig(
                 config_phase=ConfigPhase.decorator,

--- a/hyrex/task_wrapper.py
+++ b/hyrex/task_wrapper.py
@@ -3,7 +3,7 @@ import logging
 import re
 import time
 from inspect import signature
-from typing import Any, Callable, Generic, TypeVar, get_type_hints
+from typing import Any, Callable, Generic, ParamSpec, TypeVar, get_type_hints, overload
 
 import psycopg
 from pydantic import BaseModel, ValidationError
@@ -38,7 +38,11 @@ def validate_error_handler(handler: Callable) -> None:
             )
 
 
-class TaskWrapper:
+P = ParamSpec("P")  # Captures the parameter specification of the wrapped function
+R = TypeVar("R")  # Captures the return type of the wrapped function
+
+
+class TaskWrapper(Generic[P, R]):
     class ParamInfo(BaseModel):
         """Pydantic model to store parameter information"""
 
@@ -60,7 +64,7 @@ class TaskWrapper:
     def __init__(
         self,
         task_identifier: str,
-        func: Callable,
+        func: Callable[P, R],
         dispatcher: Dispatcher,
         cron: str | None,
         task_config: TaskConfig,
@@ -156,7 +160,12 @@ class TaskWrapper:
                 f"Unsupported type for retry_backoff in task {self.task_identifier}"
             )
 
-    def send(self, **kwargs) -> DurableTaskRun:
+    def send(self, *args: P.args, **kwargs: P.kwargs) -> DurableTaskRun:
+        """
+        Send this task to the Hyrex queue with the provided parameters.
+
+        This method accepts the same parameters as the wrapped function.
+        """
         self.logger.debug(
             f"Sending task {self.func.__name__} to queue: {self.task_config.queue}"
         )
@@ -278,7 +287,7 @@ class TaskWrapper:
     def __repr__(self):
         return f"TaskWrapper<{self.task_identifier}>"
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: P.args, **kwargs: P.kwargs):
         # Simply pass through all arguments to the original function
         return self.func(*args, **kwargs)
 

--- a/hyrex/task_wrapper.py
+++ b/hyrex/task_wrapper.py
@@ -15,8 +15,7 @@ from hyrex.durable_run import DurableTaskRun
 from hyrex.hyrex_context import get_hyrex_context
 from hyrex.hyrex_queue import HyrexQueue
 from hyrex.schemas import EnqueueTaskRequest, TaskStatus
-from hyrex.workflow.workflow_builder_context import \
-    get_current_workflow_builder
+from hyrex.workflow.workflow_builder_context import get_current_workflow_builder
 
 
 def validate_error_handler(handler: Callable) -> None:
@@ -40,6 +39,24 @@ def validate_error_handler(handler: Callable) -> None:
 
 
 class TaskWrapper:
+    class ParamInfo(BaseModel):
+        """Pydantic model to store parameter information"""
+
+        type_hint: Any
+        default: Any = None
+        has_default: bool = False
+
+        def __repr__(self):
+            type_name = (
+                self.type_hint.__name__
+                if hasattr(self.type_hint, "__name__")
+                else str(self.type_hint)
+            )
+            return f"ParamInfo(type_hint={type_name}, default={self.default}, has_default={self.has_default})"
+
+        class Config:
+            arbitrary_types_allowed = True  # Allow any Python type in type_hint field
+
     def __init__(
         self,
         task_identifier: str,
@@ -69,51 +86,33 @@ class TaskWrapper:
         if self.on_error:
             validate_error_handler(self.on_error)
 
-        # Check if function has arguments
-        if self.signature.parameters:
-            try:
-                # Get the first parameter
-                param_name = next(iter(self.signature.parameters))
+        # Track the parameter names and their type hints for validation
+        # Enforce that all parameters have type hints
+        self.param_info = {}
+        for param_name, param in self.signature.parameters.items():
+            # Check if type hint exists for this parameter
+            if param_name not in self.type_hints:
+                raise TypeError(
+                    f"Hyrex expects all task arguments to have type hints. Argument '{param_name}' in task '{task_identifier}' has no type hint."
+                )
 
-                # Check if type hint exists
-                if param_name not in self.type_hints:
-                    raise TypeError(
-                        f"Hyrex expects all task arguments to have type hints. Argument '{param_name}' has no type hint."
-                    )
+            # Create a Pydantic model instance for this parameter
+            self.param_info[param_name] = self.ParamInfo(
+                type_hint=self.type_hints.get(param_name),
+                default=param.default if param.default is not param.empty else None,
+                has_default=param.default is not param.empty,
+            )
 
-                self.context_klass = self.type_hints.get(param_name)
-
-                # Check if it's a Pydantic model
-                if self.context_klass is not None and not (
-                    hasattr(self.context_klass, "model_validate")
-                    or hasattr(self.context_klass, "parse_obj")
-                ):
-                    raise TypeError(
-                        f"Hyrex expects task arguments to be Pydantic models. {self.context_klass.__name__} is not a valid Pydantic model."
-                    )
-            except StopIteration:
-                self.context_klass = None
-        else:
-            self.context_klass = None
-
-    def get_arg_schema(self):
-        return self.context_klass
-
-    async def async_call(self, context=None):
+    async def async_call(self, **kwargs):
         self.logger.info(f"Executing task {self.func.__name__}.")
 
-        if context is not None and self.context_klass is not None:
-            self._check_type(context)
-            if asyncio.iscoroutinefunction(self.func):
-                return await self.func(context)
-            else:
-                return self.func(context)
+        # Validate kwargs against expected parameters
+        validated_kwargs = self._validate_kwargs(kwargs)
+
+        if asyncio.iscoroutinefunction(self.func):
+            return await self.func(**validated_kwargs)
         else:
-            # No arguments
-            if asyncio.iscoroutinefunction(self.func):
-                return await self.func()
-            else:
-                return self.func()
+            return self.func(**validated_kwargs)
 
     def with_config(
         self,
@@ -138,6 +137,7 @@ class TaskWrapper:
             cron=self.cron,
             task_config=self.task_config.merge(new_task_config),
             on_error=self.on_error,
+            retry_backoff=self.retry_backoff,
         )
         return new_wrapper
 
@@ -156,26 +156,13 @@ class TaskWrapper:
                 f"Unsupported type for retry_backoff in task {self.task_identifier}"
             )
 
-    def send(
-        self,
-        context=None,
-    ) -> DurableTaskRun:
+    def send(self, **kwargs) -> DurableTaskRun:
         self.logger.debug(
             f"Sending task {self.func.__name__} to queue: {self.task_config.queue}"
         )
 
-        # TODO: Improve this arg-checking logic
-        # Only perform type checking if we expect a context
-        if context is not None and self.context_klass is not None:
-            self._check_type(context)
-            args = context.model_dump() if hasattr(context, "model_dump") else {}
-        elif context is not None and self.context_klass is None:
-            # Task was defined with no arguments but context was provided
-            raise TypeError(
-                f"Task {self.task_identifier} was defined with no arguments, but arguments were provided."
-            )
-        else:
-            args = {}
+        # Validate the provided kwargs against our function signature
+        validated_kwargs = self._validate_kwargs(kwargs)
 
         current_context = get_hyrex_context()
 
@@ -187,7 +174,7 @@ class TaskWrapper:
             parent_id=current_context.task_id if current_context else None,
             task_name=self.task_identifier,
             queue=self.task_config.get_queue_name(),
-            args=args,
+            args=validated_kwargs,  # Pass the validated kwargs directly
             max_retries=self.task_config.max_retries,
             timeout_seconds=self.task_config.timeout_seconds,
             priority=self.task_config.priority,
@@ -205,22 +192,88 @@ class TaskWrapper:
             dispatcher=self.dispatcher,
         )
 
-    def _check_type(self, context):
-        if self.context_klass is None:
-            return
+    def _validate_kwargs(self, kwargs):
+        """
+        Validate that the provided kwargs match the function signature.
+        Apply type coercion if possible, otherwise raise appropriate errors.
+        """
+        validated_kwargs = {}
 
-        try:
-            if isinstance(context, dict):
-                validated_arg = self.context_klass.parse_obj(context)
-            elif hasattr(self.context_klass, "model_validate"):
-                validated_arg = self.context_klass.model_validate(context)
+        # Check for missing required arguments
+        for param_name, info in self.param_info.items():
+            if param_name not in kwargs and not info.has_default:
+                raise TypeError(
+                    f"Missing required argument '{param_name}' for task '{self.task_identifier}'"
+                )
+
+        # Process provided arguments
+        for param_name, value in kwargs.items():
+            if param_name not in self.param_info:
+                raise TypeError(
+                    f"Unexpected argument '{param_name}' for task '{self.task_identifier}'"
+                )
+
+            param_type = self.param_info[param_name].type_hint
+
+            # If we have a type hint, try to validate/convert the value
+            if param_type is not None:
+                try:
+                    # Handle Pydantic models for backward compatibility
+                    if hasattr(param_type, "model_validate"):
+                        validated_kwargs[param_name] = param_type.model_validate(value)
+                    elif hasattr(param_type, "parse_obj"):
+                        validated_kwargs[param_name] = param_type.parse_obj(value)
+                    # For primitive types, try basic conversion
+                    elif param_type in (int, float, str, bool) and not isinstance(
+                        value, param_type
+                    ):
+                        try:
+                            validated_kwargs[param_name] = param_type(value)
+                        except (ValueError, TypeError):
+                            raise TypeError(
+                                f"Cannot convert argument '{param_name}' value '{value}' to expected type {param_type.__name__}"
+                            )
+                    else:
+                        # For other types, just pass the value as is
+                        validated_kwargs[param_name] = value
+                except Exception as e:
+                    raise TypeError(
+                        f"Validation error for argument '{param_name}': {str(e)}"
+                    )
             else:
-                # If not a Pydantic model, assume it's the correct type
-                return
-        except ValidationError as e:
-            raise TypeError(
-                f"Invalid argument type. Expected {self.context_klass.__name__}. Error: {e}"
-            )
+                # No type hint, just use the value as is
+                validated_kwargs[param_name] = value
+
+        # Add default values for missing arguments
+        for param_name, info in self.param_info.items():
+            if param_name not in kwargs and info.has_default:
+                validated_kwargs[param_name] = info.default
+
+        return validated_kwargs
+
+    def get_arg_schema(self):
+        """
+        Return a schema describing the expected arguments for this task.
+        This is useful for documentation and UI generation.
+        """
+        schema = {}
+        for param_name, info in self.param_info.items():
+            param_type = info.type_hint
+            param_schema = {
+                "required": not info.has_default,
+                "type": param_type.__name__ if param_type else "any",
+            }
+
+            if info.has_default and info.default is not None:
+                param_schema["default"] = str(info.default)
+
+            # For Pydantic models, include their schema if available
+            if param_type and hasattr(param_type, "model_json_schema"):
+                param_schema["schema"] = param_type.model_json_schema()
+
+            schema[param_name] = param_schema
+
+        return schema
 
     def __repr__(self):
         return f"TaskWrapper<{self.task_identifier}>"

--- a/hyrex/worker/executor/executor.py
+++ b/hyrex/worker/executor/executor.py
@@ -23,16 +23,14 @@ from hyrex.dispatcher import DequeuedTask, get_dispatcher
 from hyrex.env_vars import EnvVars
 from hyrex.hyrex_app import HyrexApp, HyrexAppInfo
 from hyrex.hyrex_cache import HyrexCacheManager
-from hyrex.hyrex_context import (HyrexContext, clear_hyrex_context,
-                                 set_hyrex_context)
+from hyrex.hyrex_context import HyrexContext, clear_hyrex_context, set_hyrex_context
 from hyrex.hyrex_queue import HyrexQueue
 from hyrex.hyrex_registry import HyrexRegistry
 from hyrex.worker.executor.time_series_averager import TimeSeriesAverager
 from hyrex.worker.logging import LogLevel, init_logging
 from hyrex.worker.messages.root_messages import SetExecutorTaskMessage
 from hyrex.worker.s3_logs import write_task_logs_to_s3
-from hyrex.worker.utils import (glob_to_postgres_regex, is_glob_pattern,
-                                is_process_alive)
+from hyrex.worker.utils import glob_to_postgres_regex, is_glob_pattern, is_process_alive
 
 
 def generate_executor_name():
@@ -131,19 +129,12 @@ class WorkerExecutor(Process):
     async def process_item(self, task: DequeuedTask):
         task_wrapper = self.registry.get_task(task.task_name)
 
-        # Prepare context if needed, otherwise None
-        context = (
-            task_wrapper.context_klass(**task.args)
-            if task_wrapper.context_klass is not None
-            else None
-        )
-
-        # Execute task (async_call handles None context appropriately)
+        # Execute task with unpacked arguments
         if self.logs_s3_bucket:
             async with write_task_logs_to_s3(task.id, self.logs_s3_bucket):
-                result = await task_wrapper.async_call(context)
+                result = await task_wrapper.async_call(**task.args)
         else:
-            result = await task_wrapper.async_call(context)
+            result = await task_wrapper.async_call(**task.args)
 
         return result
 


### PR DESCRIPTION
This removes the Pydantic class restriction on task parameters and also fixes type hints so that the correct arg types are displayed when calling `send()` or calling a TaskWrapper directly as a function.