### PR TITLE
Fix idempotency_key conflict in orphan task retry

### DIFF
--- a/hyrex/dispatcher/sqlc/set_orphaned_task_execution_to_lost_and_retry.py
+++ b/hyrex/dispatcher/sqlc/set_orphaned_task_execution_to_lost_and_retry.py
@@ -64,6 +64,7 @@ SELECT
     NOW()
 FROM lost_tasks
 WHERE attempt_number < max_retries
+ON CONFLICT (task_name, idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING
 """
 
 


### PR DESCRIPTION
When the `SetOrhpanedRunningTaskToLost` job runs, it can fail with:

```
ERROR: duplicate key value violates unique constraint "ix_hyrex_task_run_idempotency_key"
  DETAIL: Key (task_name, idempotency_key)=(process_page, doc-683-page-0) already exists.
 ```
  
  which blocks all cron jobs from running. 
  
  This seems to happen when a task with an idempotencey_key becomes orphaned (executor dies), and the cron job tries to create a retry with the same key... and the insert fails due to uniqueness constraint.
  
  The fix itself feels like a patch (and was suggested by Claude Code), but putting a PR up in case it's useful! (Seems to work as a temporary patch)